### PR TITLE
Gradle: Use plugin java-library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.jetbrains.kotlin.jvm") version("1.3.50")
+    id("java-library") apply true
     id("maven") apply true
 }
 


### PR DESCRIPTION
This change exposes dependencies which are required by consumers of this library, since this library cannot be used in a context where these dependencies are not present.
The required dependencies are
- `api("com.typesafe", "config", "1.3.4")`
-  `api("io.ktor", "ktor-auth-jwt", "1.2.0")`

Without adding the `java-library` plugin, `api` does not expose the dependencies to the consumer library.